### PR TITLE
Added timeout and ability to use curl instead of restclient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+rvm:
+  - 2.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
 rvm:
-  - 2.3
+  - 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: ruby
 rvm:
   - 2.2
+
+before_install: gem update bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
 rvm:
   - 2.2
-
 before_install: gem update bundler
+script: rspec

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # fastlane-plugin-sentry `fastlane` Plugin
 
 [![fastlane Plugin Badge](https://rawcdn.githack.com/fastlane/fastlane/master/fastlane/assets/plugin-badge.svg)](https://rubygems.org/gems/fastlane-plugin-sentry)
-
+[![Build Status](https://img.shields.io/travis/getsentry/fastlane-plugin-sentry/master.svg?style=flat)](https://travis-ci.org/getsentry/fastlane-plugin-sentry)
 
 ## Getting Started
 

--- a/fastlane-plugin-sentry.gemspec
+++ b/fastlane-plugin-sentry.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rest-client', '~> 1.6.7'
 
-  spec.add_develepment_dependency 'rake'
   spec.add_develepment_dependency 'pry'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rspec'

--- a/fastlane-plugin-sentry.gemspec
+++ b/fastlane-plugin-sentry.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rest-client', '~> 1.6.7'
 
-  spec.add_development_dependency 'pry'
+  spec.add_develepment_dependency 'rake'
+  spec.add_develepment_dependency 'pry'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'fastlane', '>= 1.93.0'

--- a/fastlane-plugin-sentry.gemspec
+++ b/fastlane-plugin-sentry.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rest-client', '~> 1.6.7'
-
-  spec.add_develepment_dependency 'pry'
+  
+  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'fastlane', '>= 1.93.0'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,3 +3,9 @@ lane :test do
     dsym_path: './assets/SwiftExample.app.dSYM.zip'
   )
 end
+
+lane :test_big do
+  sentry_upload_dsym(
+    dsym_path: './assets/Big.app.dSYM.zip'
+  )
+end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -10,6 +10,11 @@ sudo gem install fastlane
 fastlane test
 ```
 
+### test_big
+```
+fastlane test_big
+```
+
 
 ----
 

--- a/lib/fastlane/plugin/sentry/version.rb
+++ b/lib/fastlane/plugin/sentry/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Sentry
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/spec/sentry_upload_dsym_spec.rb
+++ b/spec/sentry_upload_dsym_spec.rb
@@ -47,7 +47,7 @@ describe Fastlane do
               project_slug: 'some_project',
               dsym_path: '#{dsym_path_1}')
           end").runner.execute(:test)
-        end.to raise_error("dSYM does not exist at path: /Users/josh/iOS/Sentry/sentry-fastlane/fastlane-plugin-sentry/assets/this_does_not_exist.app.dSYM.zip")
+        end.to raise_error("dSYM does not exist at path: #{dsym_path_1}")
       end
 
       it "returns uploaded dSYM path using API key" do


### PR DESCRIPTION
Potentially fixes #2 (again)

`rest-client` seems to have a hard time with large file uploads. I was having uploading on of my dSYMs that was about 30MB 😱  I was getting timeouts but manually setting a higher timeout did not seem to do much of anything.

This change gives the option to manually set a timeout (which will get dropped into `rest-client`) but also gives an option to use `curl` instead of a `rest-client` which seems to behave better.

I did not make it default to `curl` yet since I like the more ruby approach (which is `rest-client`) but we may go to `curl` by default if it seems to work better after more experimentation 🚀 