### PR TITLE
Fix incorrect comparison of sentry-cli version

### DIFF
--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dsym.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dsym.rb
@@ -56,8 +56,8 @@ module Fastlane
           UI.user_error!("Install sentry-cli and start your lane again!")
         end
 
-        sentry_cli_version = `sentry-cli --version`.gsub(/[^\d]/, '').to_i
-        required_version = Fastlane::Sentry::CLI_VERSION.gsub(/[^\d]/, '').to_i
+        sentry_cli_version = Gem::Version.new(`sentry-cli --version`.scan(/(?:\d+\.?){3}/).first)
+        required_version = Gem::Version.new(Fastlane::Sentry::CLI_VERSION)
         if sentry_cli_version < required_version
           UI.user_error!("Your sentry-cli is outdated, please upgrade to at least version #{Fastlane::Sentry::CLI_VERSION} and start your lane again!")
         end


### PR DESCRIPTION
Hey everyone! 🙂

Prior to these changes the code would incorrectly report that version 1.0.0
of the sentry-cli was less than the required version of 0.25.0. The issue
was that “1.0.0” was converted to 100 and “0.25.0” was converted to 250,
and thus comparing `sentry_cli_version` to `required_version` did not
give the expected result.
Leveraging `Gem::Version`s support for parsing and comparing versions
fixes the problem.