### PR TITLE
Add actions for managing releases, files, and sourcemaps 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,255 @@
+Style/PercentLiteralDelimiters:
+  Enabled: false
+
+# kind_of? is a good way to check a type
+Style/ClassCheck:
+  EnforcedStyle: kind_of?
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+# This doesn't work with older versions of Ruby (pre 2.4.0)
+Style/SafeNavigation:
+  Enabled: false
+
+# This doesn't work with older versions of Ruby (pre 2.4.0)
+Performance/RegexpMatch:
+  Enabled: false
+
+# This suggests use of `tr` instead of `gsub`. While this might be more performant,
+# these methods are not at all interchangable, and behave very differently. This can
+# lead to people making the substitution without considering the differences.
+Performance/StringReplacement:
+  Enabled: false
+
+# .length == 0 is also good, we don't always want .zero?
+Style/NumericPredicate:
+  Enabled: false
+
+# this would cause errors with long lanes
+Metrics/BlockLength:
+  Enabled: false
+
+# this is a bit buggy
+Metrics/ModuleLength:
+  Enabled: false
+
+# certificate_1 is an okay variable name
+Style/VariableNumber:
+  Enabled: false
+
+# This is used a lot across the fastlane code base for config files
+Style/MethodMissing:
+  Enabled: false
+
+#
+#   File.chmod(0777, f)
+#
+# is easier to read than
+#
+#   File.chmod(0o777, f)
+#
+Style/NumericLiteralPrefix:
+  Enabled: false
+
+#
+# command = (!clean_expired.nil? || !clean_pattern.nil?) ? CLEANUP : LIST
+#
+# is easier to read than
+#
+# command = !clean_expired.nil? || !clean_pattern.nil? ? CLEANUP : LIST
+#
+Style/TernaryParentheses:
+  Enabled: false
+
+# sometimes it is useful to have those empty methods
+Style/EmptyMethod:
+  Enabled: false
+
+# It's better to be more explicit about the type
+Style/BracesAroundHashParameters:
+  Enabled: false
+
+# specs sometimes have useless assignments, which is fine
+Lint/UselessAssignment:
+  Exclude:
+    - '**/spec/**/*'
+
+# We could potentially enable the 2 below:
+Style/IndentHash:
+  Enabled: false
+
+Style/AlignHash:
+  Enabled: false
+
+# HoundCI doesn't like this rule
+Style/DotPosition:
+  Enabled: false
+
+# We allow !! as it's an easy way to convert ot boolean
+Style/DoubleNegation:
+  Enabled: false
+
+# Prevent to replace [] into %i
+Style/SymbolArray:
+  Enabled: false
+
+# Sometimes we allow a rescue block that doesn't contain code
+Lint/HandleExceptions:
+  Enabled: false
+
+# Cop supports --auto-correct.
+Lint/UnusedBlockArgument:
+  Enabled: false
+
+# Needed for $verbose
+Style/GlobalVars:
+  Enabled: false
+
+# We want to allow class Fastlane::Class
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+# Project uses for
+Style/For:
+  Enabled: false
+
+# $? Exit
+Style/SpecialGlobalVars:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+# The %w might be confusing for new users
+Style/WordArray:
+  MinSize: 19
+
+# raise and fail are both okay
+Style/SignalException:
+  Enabled: false
+
+# Better too much 'return' than one missing
+Style/RedundantReturn:
+  Enabled: false
+
+# Having if in the same line might not always be good
+Style/IfUnlessModifier:
+  Enabled: false
+
+# and and or is okay
+Style/AndOr:
+  Enabled: false
+
+# Configuration parameters: CountComments.
+Metrics/ClassLength:
+  Max: 320
+
+
+# Configuration parameters: AllowURI, URISchemes.
+Metrics/LineLength:
+  Max: 370
+
+# Configuration parameters: CountKeywordArgs.
+Metrics/ParameterLists:
+  Max: 17
+
+Metrics/PerceivedComplexity:
+  Max: 18
+
+# Sometimes it's easier to read without guards
+Style/GuardClause:
+  Enabled: false
+
+# We allow both " and '
+Style/StringLiterals:
+  Enabled: false
+
+# something = if something_else
+# that's confusing
+Style/ConditionalAssignment:
+  Enabled: false
+
+# Better to have too much self than missing a self
+Style/RedundantSelf:
+  Enabled: false
+
+# e.g.
+# def self.is_supported?(platform)
+# we may never use `platform`
+Lint/UnusedMethodArgument:
+  Enabled: false
+
+# the let(:key) { ... }
+Lint/ParenthesesAsGroupedExpression:
+  Exclude:
+    - '**/spec/**/*'
+
+# Allow exec in Gemfile
+Security/Eval:
+  Exclude:
+    - 'Gemfile'
+
+# This would reject is_ in front of methods
+# We use `is_supported?` everywhere already
+Style/PredicateName:
+  Enabled: false
+
+# We allow the $
+Style/PerlBackrefs:
+  Enabled: false
+
+# gemspec
+Style/UnneededPercentQ:
+  Enabled: false
+
+# Disable '+ should be surrounded with a single space' for xcodebuild_spec.rb
+Style/SpaceAroundOperators:
+  Exclude:
+    - '**/spec/actions_specs/xcodebuild_spec.rb'
+
+AllCops:
+  Include:
+    - '**/fastlane/Fastfile'
+  Exclude:
+    - '**/lib/assets/custom_action_template.rb'
+    - './vendor/**/*'
+
+# They have not to be snake_case
+Style/FileName:
+  Exclude:
+    - '*.gemspec'
+    - '**/Dangerfile'
+    - '**/Brewfile'
+    - '**/Gemfile'
+    - '**/Podfile'
+    - '**/Rakefile'
+    - '**/Fastfile'
+    - '**/Deliverfile'
+    - '**/Snapfile'
+
+# We're not there yet
+Style/Documentation:
+  Enabled: false
+
+# Added after upgrade to 0.38.0
+Style/MutableConstant:
+  Enabled: false
+
+# length > 0 is good
+Style/ZeroLengthPredicate:
+  Enabled: false
+
+# Adds complexity
+Style/IfInsideElse:
+  Enabled: false
+
+# Sometimes we just want to 'collect'
+Style/CollectionMethods:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -11,9 +11,18 @@ This project is a [fastlane](https://github.com/fastlane/fastlane) plugin. To ge
 fastlane add_plugin sentry
 ```
 
-## About sentry
+## Sentry Actions
 
-This action allows you to upload symbolication files to Sentry.
+A subset of actions provided by the CLI: https://docs.sentry.io/learn/cli/
+
+#### Authentication & Configuration
+
+`auth_token` is the preferred way to authentication method with Sentry. This can be obtained on https://sentry.io/api/.
+`api_key` still works but will eventually become deprecated. This can be obtained through the settings of your project.
+
+The following environment variables may be used in place of parameters: `SENTRY_API_KEY`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG_SLUG`, and `SENTRY_PROJECT_SLUG`.
+
+#### Uploading Symbolication Files
 
 ```ruby
 sentry_upload_dsym(
@@ -25,11 +34,47 @@ sentry_upload_dsym(
 )
 ```
 
-`auth_token` is the preferred way to authentication method with Sentry. This can be obtained on https://sentry.io/api/.
+The `SENTRY_DSYM_PATH` environment variable may be used in place of the `dsym_path` parameter.
 
-`api_key` still works but will eventually become deprecated. This can be obtained through the settings of your project.
+#### Creating & Finalizing Releases
 
-The following environment variables may be used in place of parameters: `SENTRY_API_KEY`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG_SLUG`, `SENTRY_PROJECT_SLUG`, and `SENTRY_DSYM_PATH`.
+```ruby
+sentry_create_release(
+  api_key: '...',
+  auth_token: '...',
+  org_slug: '...',
+  project_slug: '...',
+  version: '...', # release version to create
+  finalize: true # Whether to finalize the release. If not provided or false, the release can be finalized using the sentry_finalize_release action
+)
+```
+
+#### Uploading Files & Sourcemaps
+
+Useful for uploading build artifacts and JS sourcemaps for react-native apps built using fastlane.
+
+```ruby
+sentry_upload_file(
+  api_key: '...',
+  auth_token: '...',
+  org_slug: '...',
+  project_slug: '...',
+  version: '...',
+  file: 'main.jsbundle' # file to upload
+)
+```
+
+```ruby
+sentry_upload_sourcemap(
+  api_key: '...',
+  auth_token: '...',
+  org_slug: '...',
+  project_slug: '...',
+  version: '...',
+  sourcemap: 'main.jsbundle.map', # sourcemap to upload
+  rewrite: true
+)
+```
 
 ## Issues and Feedback
 

--- a/fastlane-plugin-sentry.gemspec
+++ b/fastlane-plugin-sentry.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'fastlane/plugin/sentry/version'

--- a/lib/fastlane/plugin/sentry/actions/sentry_create_release.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_create_release.rb
@@ -1,0 +1,59 @@
+module Fastlane
+  module Actions
+    class SentryCreateReleaseAction < Action
+      def self.run(params)
+        require 'shellwords'
+
+        Helper::SentryHelper.check_sentry_cli!
+        Helper::SentryConfig.parse_api_params(params)
+
+        version = params[:version]
+        finalize_arg = params[:finalize] ? ' --finalize' : ''
+
+        command = "sentry-cli releases new '#{Shellwords.escape(version)}' #{finalize_arg}"
+
+        Helper::SentryHelper.call_sentry_cli(command)
+        UI.success("Successfully created release: #{version}")
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Create new releases for a project on Sentry"
+      end
+
+      def self.details
+        [
+          "This action allows you to create new releases for a project on Sentry.",
+          "See https://docs.sentry.io/learn/cli/releases/#creating-releases for more information."
+        ].join(" ")
+      end
+
+      def self.available_options
+        Helper::SentryConfig.common_api_config_items + [
+          FastlaneCore::ConfigItem.new(key: :version,
+                                       description: "Release version to create on Sentry"),
+          FastlaneCore::ConfigItem.new(key: :finalize,
+                                       description: "Whether to finalize the release. If not provided or false, the release can be finalized using the finalize_release action",
+                                       default_value: false,
+                                       is_string: false,
+                                       optional: true)
+        ]
+      end
+
+      def self.return_value
+        nil
+      end
+
+      def self.authors
+        ["wschurman"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/sentry/actions/sentry_finalize_release.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_finalize_release.rb
@@ -1,0 +1,53 @@
+module Fastlane
+  module Actions
+    class SentryFinalizeReleaseAction < Action
+      def self.run(params)
+        require 'shellwords'
+
+        Helper::SentryHelper.check_sentry_cli!
+        Helper::SentryConfig.parse_api_params(params)
+
+        version = params[:version]
+
+        command = "sentry-cli releases finalize '#{Shellwords.escape(version)}'"
+
+        Helper::SentryHelper.call_sentry_cli(command)
+        UI.success("Successfully finalized release: #{version}")
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Finalize a release for a project on Sentry"
+      end
+
+      def self.details
+        [
+          "This action allows you to finalize releases created for a project on Sentry.",
+          "See https://docs.sentry.io/learn/cli/releases/#finalizing-releases for more information."
+        ].join(" ")
+      end
+
+      def self.available_options
+        Helper::SentryConfig.common_api_config_items + [
+          FastlaneCore::ConfigItem.new(key: :version,
+                                       description: "Release version to finalize on Sentry")
+        ]
+      end
+
+      def self.return_value
+        nil
+      end
+
+      def self.authors
+        ["wschurman"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dsym.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dsym.rb
@@ -16,8 +16,6 @@ module Fastlane
           UI.user_error!("dSYM does not exist at path: #{path}") unless File.exist? path
         end
 
-        UI.success("sentry-cli #{Fastlane::Sentry::CLI_VERSION} installed!")
-
         command = "sentry-cli upload-dsym '#{dsym_paths.join("','")}'"
 
         Helper::SentryHelper.call_sentry_cli(command)
@@ -46,19 +44,13 @@ module Fastlane
                                        env_name: "SENTRY_DSYM_PATH",
                                        description: "Path to your symbols file. For iOS and Mac provide path to app.dSYM.zip",
                                        default_value: Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH],
-                                       optional: true,
-                                       verify_block: proc do |value|
-                                         # validation is done in the action
-                                       end),
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :dsym_paths,
                                        env_name: "SENTRY_DSYM_PATHS",
                                        description: "Path to an array of your symbols file. For iOS and Mac provide path to app.dSYM.zip",
                                        default_value: Actions.lane_context[SharedValues::DSYM_PATHS],
                                        is_string: false,
-                                       optional: true,
-                                       verify_block: proc do |value|
-                                         # validation is done in the action
-                                       end)
+                                       optional: true)
 
         ]
       end

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dsym.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dsym.rb
@@ -2,7 +2,7 @@ module Fastlane
   module Actions
     class SentryUploadDsymAction < Action
       def self.run(params)
-        check_sentry_cli!
+        Helper::SentryHelper.check_sentry_cli!
 
         # Params - API
         url = params[:url]
@@ -42,25 +42,6 @@ module Fastlane
         UI.success("sentry-cli #{Fastlane::Sentry::CLI_VERSION} installed!")
         call_sentry_cli(dsym_paths, org, project)
         UI.success("Successfully uploaded dSYMs!")
-      end
-
-      def self.check_sentry_cli!
-        if !`which sentry-cli`.include?('sentry-cli')
-          UI.error("You have to install sentry-cli version #{Fastlane::Sentry::CLI_VERSION} to use this plugin")
-          UI.error("")
-          UI.error("Install it using:")
-          UI.command("brew install getsentry/tools/sentry-cli")
-          UI.error("OR")
-          UI.command("curl -sL https://sentry.io/get-cli/ | bash")
-          UI.error("If you don't have homebrew, visit http://brew.sh")
-          UI.user_error!("Install sentry-cli and start your lane again!")
-        end
-
-        sentry_cli_version = Gem::Version.new(`sentry-cli --version`.scan(/(?:\d+\.?){3}/).first)
-        required_version = Gem::Version.new(Fastlane::Sentry::CLI_VERSION)
-        if sentry_cli_version < required_version
-          UI.user_error!("Your sentry-cli is outdated, please upgrade to at least version #{Fastlane::Sentry::CLI_VERSION} and start your lane again!")
-        end
       end
 
       def self.call_sentry_cli(dsym_paths, org, project)

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dsym.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dsym.rb
@@ -40,50 +40,14 @@ module Fastlane
         end
 
         UI.success("sentry-cli #{Fastlane::Sentry::CLI_VERSION} installed!")
-        call_sentry_cli(dsym_paths, org, project)
-        UI.success("Successfully uploaded dSYMs!")
-      end
 
-      def self.call_sentry_cli(dsym_paths, org, project)
-        UI.message "Starting sentry-cli..."
-        require 'open3'
         require 'shellwords'
         org = Shellwords.escape(org)
         project = Shellwords.escape(project)
-        error = []
         command = "sentry-cli upload-dsym '#{dsym_paths.join("','")}' --org #{org} --project #{project}"
-        if FastlaneCore::Globals.verbose?
-          UI.verbose("sentry-cli command:\n\n")
-          UI.command(command.to_s)
-          UI.verbose("\n\n")
-        end
-        Open3.popen3(command) do |stdin, stdout, stderr, wait_thr|
-          while (line = stderr.gets)
-            error << line.strip!
-          end
-          while (line = stdout.gets)
-            UI.message(line.strip!)
-          end
-          exit_status = wait_thr.value
-          unless exit_status.success? && error.empty?
-            handle_error(error)
-          end
-        end
-      end
 
-      def self.handle_error(errors)
-        fatal = false
-        for error in errors do
-          if error
-            if error =~ /error/
-              UI.error(error.to_s)
-              fatal = true
-            else
-              UI.verbose(error.to_s)
-            end
-          end
-        end
-        UI.user_error!('Error while trying to upload dSYM to Sentry') if fatal
+        Helper::SentryHelper.call_sentry_cli(command)
+        UI.success("Successfully uploaded dSYMs!")
       end
 
       #####################################################

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dsym.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dsym.rb
@@ -36,7 +36,7 @@ module Fastlane
         dsym_paths += [dsym_path] unless dsym_path.nil?
         dsym_paths = dsym_paths.map { |path| File.absolute_path(path) }
         dsym_paths.each do |path|
-          UI.user_error!("dSYM does not exist at path: #{path}") unless File.exists? path
+          UI.user_error!("dSYM does not exist at path: #{path}") unless File.exist? path
         end
 
         UI.success("sentry-cli #{Fastlane::Sentry::CLI_VERSION} installed!")
@@ -54,14 +54,14 @@ module Fastlane
         command = "sentry-cli upload-dsym '#{dsym_paths.join("','")}' --org #{org} --project #{project}"
         if FastlaneCore::Globals.verbose?
           UI.verbose("sentry-cli command:\n\n")
-          UI.command("#{command}")
+          UI.command(command.to_s)
           UI.verbose("\n\n")
         end
         Open3.popen3(command) do |stdin, stdout, stderr, wait_thr|
-          while line = stderr.gets do
-              error << line.strip!
+          while (line = stderr.gets)
+            error << line.strip!
           end
-          while line = stdout.gets do
+          while (line = stdout.gets)
             UI.message(line.strip!)
           end
           exit_status = wait_thr.value
@@ -75,15 +75,15 @@ module Fastlane
         fatal = false
         for error in errors do
           if error
-            if /error/.match(error)
-              UI.error("#{error}")
+            if error =~ /error/
+              UI.error(error.to_s)
               fatal = true
             else
-              UI.verbose("#{error}")
+              UI.verbose(error.to_s)
             end
           end
         end
-        UI.user_error!('Error while trying to upload dSYM to Sentry') unless !fatal
+        UI.user_error!('Error while trying to upload dSYM to Sentry') if fatal
       end
 
       #####################################################
@@ -108,8 +108,7 @@ module Fastlane
                                        env_name: "SENTRY_URL",
                                        description: "Url for Sentry",
                                        is_string: true,
-                                       optional: true
-                                      ),
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :auth_token,
                                        env_name: "SENTRY_AUTH_TOKEN",
                                        description: "Authentication token for Sentry",

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dsym.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dsym.rb
@@ -3,34 +3,11 @@ module Fastlane
     class SentryUploadDsymAction < Action
       def self.run(params)
         Helper::SentryHelper.check_sentry_cli!
-
-        # Params - API
-        url = params[:url]
-        auth_token = params[:auth_token]
-        api_key = params[:api_key]
-        org = params[:org_slug]
-        project = params[:project_slug]
+        Helper::SentryConfig.parse_api_params(params)
 
         # Params - dSYM
         dsym_path = params[:dsym_path]
         dsym_paths = params[:dsym_paths] || []
-
-        has_api_key = !api_key.to_s.empty?
-        has_auth_token = !auth_token.to_s.empty?
-
-        # Will fail if none or both authentication methods are provided
-        if !has_api_key && !has_auth_token
-          UI.user_error!("No API key or authentication token found for SentryAction given, pass using `api_key: 'key'` or `auth_token: 'token'`")
-        elsif has_api_key && has_auth_token
-          UI.user_error!("Both API key and authentication token found for SentryAction given, please only give one")
-        elsif has_api_key && !has_auth_token
-          UI.deprecated("Please consider switching to auth_token ... api_key will be removed in the future")
-        end
-
-        ENV['SENTRY_API_KEY'] = api_key unless api_key.to_s.empty?
-        ENV['SENTRY_AUTH_TOKEN'] = auth_token unless auth_token.to_s.empty?
-        ENV['SENTRY_URL'] = url unless url.to_s.empty?
-        ENV['SENTRY_LOG_LEVEL'] = 'debug' if FastlaneCore::Globals.verbose?
 
         # Verify dsym(s)
         dsym_paths += [dsym_path] unless dsym_path.nil?
@@ -41,10 +18,7 @@ module Fastlane
 
         UI.success("sentry-cli #{Fastlane::Sentry::CLI_VERSION} installed!")
 
-        require 'shellwords'
-        org = Shellwords.escape(org)
-        project = Shellwords.escape(project)
-        command = "sentry-cli upload-dsym '#{dsym_paths.join("','")}' --org #{org} --project #{project}"
+        command = "sentry-cli upload-dsym '#{dsym_paths.join("','")}'"
 
         Helper::SentryHelper.call_sentry_cli(command)
         UI.success("Successfully uploaded dSYMs!")
@@ -67,32 +41,7 @@ module Fastlane
       end
 
       def self.available_options
-        [
-          FastlaneCore::ConfigItem.new(key: :url,
-                                       env_name: "SENTRY_URL",
-                                       description: "Url for Sentry",
-                                       is_string: true,
-                                       optional: true),
-          FastlaneCore::ConfigItem.new(key: :auth_token,
-                                       env_name: "SENTRY_AUTH_TOKEN",
-                                       description: "Authentication token for Sentry",
-                                       optional: true),
-          FastlaneCore::ConfigItem.new(key: :api_key,
-                                       env_name: "SENTRY_API_KEY",
-                                       description: "API key for Sentry",
-                                       optional: true),
-          FastlaneCore::ConfigItem.new(key: :org_slug,
-                                       env_name: "SENTRY_ORG_SLUG",
-                                       description: "Organization slug for Sentry project",
-                                       verify_block: proc do |value|
-                                         UI.user_error!("No organization slug for SentryAction given, pass using `org_slug: 'org'`") unless value and !value.empty?
-                                       end),
-          FastlaneCore::ConfigItem.new(key: :project_slug,
-                                       env_name: "SENTRY_PROJECT_SLUG",
-                                       description: "Project slug for Sentry",
-                                       verify_block: proc do |value|
-                                         UI.user_error!("No project slug for SentryAction given, pass using `project_slug: 'project'`") unless value and !value.empty?
-                                       end),
+        Helper::SentryConfig.common_api_config_items + [
           FastlaneCore::ConfigItem.new(key: :dsym_path,
                                        env_name: "SENTRY_DSYM_PATH",
                                        description: "Path to your symbols file. For iOS and Mac provide path to app.dSYM.zip",

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_file.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_file.rb
@@ -1,0 +1,63 @@
+module Fastlane
+  module Actions
+    class SentryUploadFileAction < Action
+      def self.run(params)
+        require 'shellwords'
+
+        Helper::SentryHelper.check_sentry_cli!
+        Helper::SentryConfig.parse_api_params(params)
+
+        version = params[:version]
+        file = params[:file]
+        file_url_arg = params[:file_url] ? "'#{params[:file_url]}'" : ''
+
+        command = "sentry-cli releases files '#{Shellwords.escape(version)}' upload #{file} #{file_url_arg}"
+
+        Helper::SentryHelper.call_sentry_cli(command)
+        UI.success("Successfully uploaded files to release: #{version}")
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Upload files to a release of a project on Sentry"
+      end
+
+      def self.details
+        [
+          "This action allows you to upload files to a release of a project on Sentry.",
+          "See https://docs.sentry.io/learn/cli/releases/#upload-files for more information."
+        ].join(" ")
+      end
+
+      def self.available_options
+        Helper::SentryConfig.common_api_config_items + [
+          FastlaneCore::ConfigItem.new(key: :version,
+                                       description: "Release version on Sentry"),
+          FastlaneCore::ConfigItem.new(key: :file,
+                                       description: "Path to the file to upload",
+                                       verify_block: proc do |value|
+                                         UI.user_error! "Could not find file at path '#{value}'" unless File.exist?(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :file_url,
+                                       description: "Optional URL we should associate with the file",
+                                       optional: true)
+        ]
+      end
+
+      def self.return_value
+        nil
+      end
+
+      def self.authors
+        ["wschurman"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
@@ -1,0 +1,96 @@
+module Fastlane
+  module Actions
+    class SentryUploadSourcemapAction < Action
+      def self.run(params)
+        require 'shellwords'
+
+        Helper::SentryHelper.check_sentry_cli!
+        Helper::SentryConfig.parse_api_params(params)
+
+        version = params[:version]
+        sourcemap = params[:sourcemap]
+
+        rewrite_arg = params[:rewrite] ? '--rewrite' : ''
+        strip_prefix_arg = params[:strip_prefix] ? '--strip-prefix' : ''
+        strip_common_prefix_arg = params[:strip_common_prefix] ? '--strip-common-prefix' : ''
+        url_prefix_arg = params[:url_prefix] ? "--url-prefix '#{params[:url_prefix]}'" : ''
+
+        command = [
+          "sentry-cli",
+          "releases",
+          "files",
+          "'#{Shellwords.escape(version)}'",
+          "upload-sourcemaps",
+          sourcemap.to_s,
+          rewrite_arg,
+          strip_prefix_arg,
+          strip_common_prefix_arg,
+          url_prefix_arg
+        ].join(" ")
+
+        Helper::SentryHelper.call_sentry_cli(command)
+        UI.success("Successfully uploaded files to release: #{version}")
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Upload a sourcemap to a release of a project on Sentry"
+      end
+
+      def self.details
+        [
+          "This action allows you to upload a sourcemap to a release of a project on Sentry.",
+          "See https://docs.sentry.io/learn/cli/releases/#upload-sourcemaps for more information."
+        ].join(" ")
+      end
+
+      def self.available_options
+        Helper::SentryConfig.common_api_config_items + [
+          FastlaneCore::ConfigItem.new(key: :version,
+                                       description: "Release version on Sentry"),
+          FastlaneCore::ConfigItem.new(key: :sourcemap,
+                                       description: "Path to the sourcemap to upload",
+                                       verify_block: proc do |value|
+                                         UI.user_error! "Could not find sourcemap at path '#{value}'" unless File.exist?(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :rewrite,
+                                       description: "Rewrite the sourcemaps before upload",
+                                       default_value: false,
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :strip_prefix,
+                                       conflicting_options: [:strip_common_prefix],
+                                       description: "Chop-off a prefix from uploaded files",
+                                       default_value: false,
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :strip_common_prefix,
+                                       conflicting_options: [:strip_prefix],
+                                       description: "Automatically guess what the common prefix is and chop that one off automatically",
+                                       default_value: false,
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :url_prefix,
+                                       description: "Sets a URL prefix in front of all files",
+                                       optional: true)
+
+        ]
+      end
+
+      def self.return_value
+        nil
+      end
+
+      def self.authors
+        ["wschurman"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/sentry/helper/sentry_config.rb
+++ b/lib/fastlane/plugin/sentry/helper/sentry_config.rb
@@ -1,0 +1,64 @@
+module Fastlane
+  module Helper
+    class SentryConfig
+      def self.common_api_config_items
+        [
+          FastlaneCore::ConfigItem.new(key: :url,
+                                       env_name: "SENTRY_URL",
+                                       description: "Url for Sentry",
+                                       is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :auth_token,
+                                       env_name: "SENTRY_AUTH_TOKEN",
+                                       description: "Authentication token for Sentry",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :api_key,
+                                       env_name: "SENTRY_API_KEY",
+                                       description: "API key for Sentry",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :org_slug,
+                                       env_name: "SENTRY_ORG_SLUG",
+                                       description: "Organization slug for Sentry project",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No organization slug for SentryAction given, pass using `org_slug: 'org'`") unless value and !value.empty?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :project_slug,
+                                       env_name: "SENTRY_PROJECT_SLUG",
+                                       description: "Project slug for Sentry",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No project slug for SentryAction given, pass using `project_slug: 'project'`") unless value and !value.empty?
+                                       end)
+        ]
+      end
+
+      def self.parse_api_params(params)
+        require 'shellwords'
+
+        url = params[:url]
+        auth_token = params[:auth_token]
+        api_key = params[:api_key]
+        org = params[:org_slug]
+        project = params[:project_slug]
+
+        has_api_key = !api_key.to_s.empty?
+        has_auth_token = !auth_token.to_s.empty?
+
+        # Will fail if none or both authentication methods are provided
+        if !has_api_key && !has_auth_token
+          UI.user_error!("No API key or authentication token found for SentryAction given, pass using `api_key: 'key'` or `auth_token: 'token'`")
+        elsif has_api_key && has_auth_token
+          UI.user_error!("Both API key and authentication token found for SentryAction given, please only give one")
+        elsif has_api_key && !has_auth_token
+          UI.deprecated("Please consider switching to auth_token ... api_key will be removed in the future")
+        end
+
+        ENV['SENTRY_API_KEY'] = api_key unless api_key.to_s.empty?
+        ENV['SENTRY_AUTH_TOKEN'] = auth_token unless auth_token.to_s.empty?
+        ENV['SENTRY_URL'] = url unless url.to_s.empty?
+        ENV['SENTRY_LOG_LEVEL'] = 'debug' if FastlaneCore::Globals.verbose?
+        ENV['SENTRY_ORG'] = Shellwords.escape(org) unless org.to_s.empty?
+        ENV['SENTRY_PROJECT'] = Shellwords.escape(project) unless project.to_s.empty?
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/sentry/helper/sentry_helper.rb
+++ b/lib/fastlane/plugin/sentry/helper/sentry_helper.rb
@@ -2,7 +2,7 @@ module Fastlane
   module Helper
     class SentryHelper
       def self.check_sentry_cli!
-        if !`which sentry-cli`.include?('sentry-cli')
+        unless `which sentry-cli`.include?('sentry-cli')
           UI.error("You have to install sentry-cli version #{Fastlane::Sentry::CLI_VERSION} to use this plugin")
           UI.error("")
           UI.error("Install it using:")

--- a/lib/fastlane/plugin/sentry/helper/sentry_helper.rb
+++ b/lib/fastlane/plugin/sentry/helper/sentry_helper.rb
@@ -1,11 +1,23 @@
 module Fastlane
   module Helper
     class SentryHelper
-      # class methods that you define here become available in your action
-      # as `Helper::SentryHelper.your_method`
-      #
-      def self.show_message
-        UI.message("Hello from the sentry plugin helper!")
+      def self.check_sentry_cli!
+        if !`which sentry-cli`.include?('sentry-cli')
+          UI.error("You have to install sentry-cli version #{Fastlane::Sentry::CLI_VERSION} to use this plugin")
+          UI.error("")
+          UI.error("Install it using:")
+          UI.command("brew install getsentry/tools/sentry-cli")
+          UI.error("OR")
+          UI.command("curl -sL https://sentry.io/get-cli/ | bash")
+          UI.error("If you don't have homebrew, visit http://brew.sh")
+          UI.user_error!("Install sentry-cli and start your lane again!")
+        end
+
+        sentry_cli_version = Gem::Version.new(`sentry-cli --version`.scan(/(?:\d+\.?){3}/).first)
+        required_version = Gem::Version.new(Fastlane::Sentry::CLI_VERSION)
+        if sentry_cli_version < required_version
+          UI.user_error!("Your sentry-cli is outdated, please upgrade to at least version #{Fastlane::Sentry::CLI_VERSION} and start your lane again!")
+        end
       end
     end
   end

--- a/lib/fastlane/plugin/sentry/helper/sentry_helper.rb
+++ b/lib/fastlane/plugin/sentry/helper/sentry_helper.rb
@@ -18,6 +18,8 @@ module Fastlane
         if sentry_cli_version < required_version
           UI.user_error!("Your sentry-cli is outdated, please upgrade to at least version #{Fastlane::Sentry::CLI_VERSION} and start your lane again!")
         end
+
+        UI.success("sentry-cli #{sentry_cli_version} installed!")
       end
 
       def self.call_sentry_cli(command)

--- a/spec/sentry_config_spec.rb
+++ b/spec/sentry_config_spec.rb
@@ -1,0 +1,18 @@
+describe Fastlane::Helper::SentryConfig do
+  describe "parse_api_params" do
+    it "fails with no API key or auth token" do
+      expect do
+        Fastlane::Helper::SentryConfig.parse_api_params({})
+      end.to raise_error("No API key or authentication token found for SentryAction given, pass using `api_key: 'key'` or `auth_token: 'token'`")
+    end
+
+    it "fails with API key and auth token" do
+      expect do
+        Fastlane::Helper::SentryConfig.parse_api_params({
+          api_key: 'something123',
+          auth_token: 'something123'
+        })
+      end.to raise_error("Both API key and authentication token found for SentryAction given, please only give one")
+    end
+  end
+end

--- a/spec/sentry_upload_dsym_spec.rb
+++ b/spec/sentry_upload_dsym_spec.rb
@@ -1,12 +1,6 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "sentry" do
-      before(:each) do
-        # result = Fastlane::FastFile.new.parse("lane :test do
-        #   gym()
-        # end").runner.execute(:test)
-      end
-
       it "fails with no API key or auth token" do
         dsym_path_1 = File.absolute_path './assets/SwiftExample.app.dSYM.zip'
 

--- a/spec/sentry_upload_dsym_spec.rb
+++ b/spec/sentry_upload_dsym_spec.rb
@@ -2,17 +2,16 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "sentry" do
       before(:each) do
-        #result = Fastlane::FastFile.new.parse("lane :test do
-        #  gym()
-        #end").runner.execute(:test)
+        # result = Fastlane::FastFile.new.parse("lane :test do
+        #   gym()
+        # end").runner.execute(:test)
       end
-
 
       it "fails with no API key or auth token" do
         dsym_path_1 = File.absolute_path './assets/SwiftExample.app.dSYM.zip'
 
         expect do
-          result = Fastlane::FastFile.new.parse("lane :test do
+          Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dsym(
               org_slug: 'some_org',
               project_slug: 'some_project',
@@ -25,7 +24,7 @@ describe Fastlane do
         dsym_path_1 = File.absolute_path './assets/SwiftExample.app.dSYM.zip'
 
         expect do
-          result = Fastlane::FastFile.new.parse("lane :test do
+          Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dsym(
               org_slug: 'some_org',
               api_key: 'something123',
@@ -40,7 +39,7 @@ describe Fastlane do
         dsym_path_1 = File.absolute_path './assets/this_does_not_exist.app.dSYM.zip'
 
         expect do
-          result = Fastlane::FastFile.new.parse("lane :test do
+          Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dsym(
               org_slug: 'some_org',
               api_key: 'something123',

--- a/spec/sentry_upload_file_spec.rb
+++ b/spec/sentry_upload_file_spec.rb
@@ -1,0 +1,18 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "sentry" do
+      it "fails with invalid file path" do
+        file_path = File.absolute_path './assets/this_does_not_exist.js'
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_file(
+              org_slug: 'some_org',
+              api_key: 'something123',
+              project_slug: 'some_project',
+              file: '#{file_path}')
+          end").runner.execute(:test)
+        end.to raise_error("Could not find file at path '#{file_path}'")
+      end
+    end
+  end
+end

--- a/spec/sentry_upload_sourcemap_spec.rb
+++ b/spec/sentry_upload_sourcemap_spec.rb
@@ -1,0 +1,18 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "sentry" do
+      it "fails with invalid sourcemap path" do
+        sourcemap_path = File.absolute_path './assets/this_does_not_exist.js.map'
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_sourcemap(
+              org_slug: 'some_org',
+              api_key: 'something123',
+              project_slug: 'some_project',
+              sourcemap: '#{sourcemap_path}')
+          end").runner.execute(:test)
+        end.to raise_error("Could not find sourcemap at path '#{sourcemap_path}'")
+      end
+    end
+  end
+end


### PR DESCRIPTION
With fastlane use in react-native apps, these tasks are needed to upload JS bundles and their sourcemaps to releases. This set of commits adds more of the CLI functionality to fastlane actions to avoid having to curl manually in a project's Fastfile.

### Overview of Changes
- Refactor common code in preparation for new actions
- Add Rubocop configuration to ensure code style consistency between actions
- Add four new actions: `sentry_create_release`, `sentry_finalize_release`, `sentry_upload_file`, and `sentry_upload_sourcemap`. Each action has the same authentication param signature as the existing dsym action.

### Test Plan

1. Run added rspec tests to test basic param handling and param validation.
2. In private project using Sentry and fastlane, replace existing curl commands with new Sentry plugin commands and run the lane. Ensure that the releases are successfully created and the artifacts are successfully uploaded.

Comments and change requests welcome!

Example Fastfile migration:

Before:

```ruby
create_release_command = %(cd #{ENV['PWD']} && \
  curl https://sentry.io/api/0/projects/#{sentry_organisation}/#{sentry_app_name}/releases/ \
  -X POST -H 'Authorization: Bearer #{sentry_token}' \
 -H 'Content-Type: application/json' \
 -d '{"version": "#{sentry_release}"}')
sh(create_release_command)

upload_jsbundle_command = %(cd #{ENV['PWD']} && \
  curl https://sentry.io/api/0/projects/#{sentry_organisation}/#{sentry_app_name}/releases/#{sentry_release}/files/ \
  -X POST \
  -H 'Authorization: Bearer  #{sentry_token}' \
  -F file=@main.jsbundle \
  -F name="/main.jsbundle")
sh(upload_jsbundle_command)

upload_jsbundlemap_command = %(cd #{ENV['PWD']} && \
  curl https://sentry.io/api/0/projects/#{sentry_organisation}/#{sentry_app_name}/releases/#{sentry_release}/files/ \
  -X POST \
  -H 'Authorization: Bearer  #{sentry_token}' \
  -F file=@main.jsbundle.map \
  -F name="/main.jsbundle.map")
sh(upload_jsbundlemap_command)
```

After:

```ruby
sentry_create_release(
  auth_token: sentry_token,
  org_slug: sentry_organisation,
  project_slug: sentry_app_name,
  version: sentry_release,
  finalize: true
)

sentry_upload_file(
  auth_token: sentry_token,
  org_slug: sentry_organisation,
  project_slug: sentry_app_name,
  version: sentry_release,
  file: 'main.jsbundle'
)

sentry_upload_sourcemap(
  auth_token: sentry_token,
  org_slug: sentry_organisation,
  project_slug: sentry_app_name,
  version: sentry_release,
  sourcemap: 'main.jsbundle.map',
  rewrite: true
)
```