### PR TITLE
Use info instead of debug for verbose

### DIFF
--- a/lib/fastlane/plugin/sentry/helper/sentry_config.rb
+++ b/lib/fastlane/plugin/sentry/helper/sentry_config.rb
@@ -58,7 +58,7 @@ module Fastlane
           ENV['SENTRY_API_KEY'] = api_key unless api_key.to_s.empty?
           ENV['SENTRY_AUTH_TOKEN'] = auth_token unless auth_token.to_s.empty?
           ENV['SENTRY_URL'] = url unless url.to_s.empty?
-          ENV['SENTRY_LOG_LEVEL'] = 'debug' if FastlaneCore::Globals.verbose?
+          ENV['SENTRY_LOG_LEVEL'] = 'INFO' if FastlaneCore::Globals.verbose?
           ENV['SENTRY_ORG'] = Shellwords.escape(org) unless org.to_s.empty?
           ENV['SENTRY_PROJECT'] = Shellwords.escape(project) unless project.to_s.empty?
         else


### PR DESCRIPTION
I think that `debug` is [a bit too much](https://github.com/getsentry/sentry-cli/issues/68) for when you're asking for verbose at Fastlane level

I also made it uppercase, because that's what the CLI recommends:

```sh
 ~/d/p/o/r/fastlane-plugin-sentry   master  sentry-cli --help                                                                                                                                                                                                                                                                            245ms  Mon 15 May 16:25:14 2017
sentry-cli 1.9.1

Command line utility for Sentry.

This tool helps you managing remote resources on a Sentry server like
sourcemaps, debug symbols, releases or similar.  Use `--help` on the
subcommands to learn more about them.

USAGE:
    sentry-cli <SUBCOMMAND>

OPTIONS:
        --api-key <API_KEY>          The sentry API key to use
        --auth-token <AUTH_TOKEN>    The sentry auth token to use
    -h, --help                       Prints help information
        --log-level <LOG_LEVEL>      The log level for sentry-cli
                                     (valid levels: TRACE, DEBUG, INFO, WARN, ERROR)
        --url <URL>                  The sentry API URL
                                     defaults to https://sentry.io/
    -V, --version                    Prints version information
```

