### PR TITLE
Update readme to indicate specifying false for dist prior behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ sentry_upload_file(
   project_slug: '...',
   version: '...',
   app_identifier: '...', # pass in the bundle_identifer of your app
-  dist: '...', # distribution of the release usually the buildnumber
+  dist: '...', # distribution of the release usually the buildnumber, false for 'None'
   file: 'main.jsbundle' # file to upload
 )
 ```
@@ -76,7 +76,7 @@ sentry_upload_sourcemap(
   project_slug: '...',
   version: '...',
   app_identifier: '...', # pass in the bundle_identifer of your app
-  dist: '...', # distribution of the release usually the buildnumber
+  dist: '...', # distribution of the release usually the buildnumber, false for 'None'
   sourcemap: 'main.jsbundle.map', # sourcemap to upload
   rewrite: true
 )

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ sentry_upload_file(
   project_slug: '...',
   version: '...',
   app_identifier: '...', # pass in the bundle_identifer of your app
-  dist: '...', # distribution of the release usually the buildnumber, false for 'None'
+  dist: '...', # optional distribution of the release usually the buildnumber
   file: 'main.jsbundle' # file to upload
 )
 ```
@@ -76,7 +76,7 @@ sentry_upload_sourcemap(
   project_slug: '...',
   version: '...',
   app_identifier: '...', # pass in the bundle_identifer of your app
-  dist: '...', # distribution of the release usually the buildnumber, false for 'None'
+  dist: '...', # optional distribution of the release usually the buildnumber
   sourcemap: 'main.jsbundle.map', # sourcemap to upload
   rewrite: true
 )

--- a/lib/fastlane/plugin/sentry/actions/sentry_create_release.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_create_release.rb
@@ -10,8 +10,6 @@ module Fastlane
         version = params[:version]
         version = "#{params[:app_identifier]}-#{params[:version]}" if params[:app_identifier]
 
-        #finalize_arg = params[:finalize] ? '--finalize'
-
         command = [
           "sentry-cli",
           "releases",

--- a/lib/fastlane/plugin/sentry/actions/sentry_create_release.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_create_release.rb
@@ -10,9 +10,15 @@ module Fastlane
         version = params[:version]
         version = "#{params[:app_identifier]}-#{params[:version]}" if params[:app_identifier]
 
-        finalize_arg = params[:finalize] ? ' --finalize' : ''
+        #finalize_arg = params[:finalize] ? '--finalize'
 
-        command = "sentry-cli releases new '#{Shellwords.escape(version)}' #{finalize_arg}"
+        command = [
+          "sentry-cli",
+          "releases",
+          "new",
+          Shellwords.escape(version)
+        ]
+        command.push("--finalize") if params[:finalize].nil?
 
         Helper::SentryHelper.call_sentry_cli(command)
         UI.success("Successfully created release: #{version}")

--- a/lib/fastlane/plugin/sentry/actions/sentry_create_release.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_create_release.rb
@@ -14,7 +14,7 @@ module Fastlane
           "sentry-cli",
           "releases",
           "new",
-          Shellwords.escape(version)
+          version
         ]
         command.push("--finalize") if params[:finalize].nil?
 

--- a/lib/fastlane/plugin/sentry/actions/sentry_finalize_release.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_finalize_release.rb
@@ -8,12 +8,13 @@ module Fastlane
         Helper::SentryConfig.parse_api_params(params)
 
         version = params[:version]
+        version = "#{params[:app_identifier]}-#{params[:version]}" if params[:app_identifier]
 
         command = [
           "sentry-cli",
           "releases",
           "finalize",
-          Shellwords.escape(version)
+          version
         ]
 
         Helper::SentryHelper.call_sentry_cli(command)
@@ -38,7 +39,14 @@ module Fastlane
       def self.available_options
         Helper::SentryConfig.common_api_config_items + [
           FastlaneCore::ConfigItem.new(key: :version,
-                                       description: "Release version to finalize on Sentry")
+                                       description: "Release version to finalize on Sentry"),
+          FastlaneCore::ConfigItem.new(key: :app_identifier,
+                                      short_option: "-a",
+                                      env_name: "SENTRY_APP_IDENTIFIER",
+                                      description: "App Bundle Identifier",
+                                      optional: true,
+                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier))
+
         ]
       end
 

--- a/lib/fastlane/plugin/sentry/actions/sentry_finalize_release.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_finalize_release.rb
@@ -9,7 +9,12 @@ module Fastlane
 
         version = params[:version]
 
-        command = "sentry-cli releases finalize '#{Shellwords.escape(version)}'"
+        command = [
+          "sentry-cli",
+          "releases",
+          "finalize",
+          Shellwords.escape(version)
+        ]
 
         Helper::SentryHelper.call_sentry_cli(command)
         UI.success("Successfully finalized release: #{version}")

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dsym.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dsym.rb
@@ -16,7 +16,7 @@ module Fastlane
           UI.user_error!("dSYM does not exist at path: #{path}") unless File.exist? path
         end
 
-        command = "sentry-cli upload-dsym '#{dsym_paths.join("','")}'"
+        command = ["sentry-cli", "upload-dsym"] + dsym_paths
 
         Helper::SentryHelper.call_sentry_cli(command)
         UI.success("Successfully uploaded dSYMs!")

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_file.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_file.rb
@@ -20,8 +20,8 @@ module Fastlane
           "upload",
           file
         ]
-        command.push(params[:file_url]) if !params[:file_url].nil?
-        command.push("--dist").push(params[:dist]) if !params[:dist].nil?
+        command.push(params[:file_url]) unless params[:file_url].nil?
+        command.push("--dist").push(params[:dist]) unless params[:dist].nil?
 
         Helper::SentryHelper.call_sentry_cli(command)
         UI.success("Successfully uploaded files to release: #{version}")

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_file.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_file.rb
@@ -9,12 +9,19 @@ module Fastlane
 
         version = params[:version]
         file = params[:file]
-        file_url_arg = params[:file_url] ? "'#{params[:file_url]}'" : ''
-        dist_arg = params[:dist] ? "--dist '#{params[:dist]}'" : ''
 
         version = "#{params[:app_identifier]}-#{params[:version]}" if params[:app_identifier]
 
-        command = "sentry-cli releases files '#{Shellwords.escape(version)}' upload #{file} #{file_url_arg} #{dist_arg}"
+        command = [
+          "sentry-cli",
+          "releases",
+          "files",
+          Shellwords.escape(version),
+          "upload",
+          file
+        ]
+        command.push(params[:file_url]) if !params[:file_url].nil?
+        command.push("--dist").push(params[:dist]) if !params[:dist].nil?
 
         Helper::SentryHelper.call_sentry_cli(command)
         UI.success("Successfully uploaded files to release: #{version}")

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_file.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_file.rb
@@ -47,7 +47,8 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version,
                                        description: "Release version on Sentry"),
           FastlaneCore::ConfigItem.new(key: :dist,
-                                       description: "Distribution in release"),
+                                       description: "Distribution in release",
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :file,
                                        description: "Path to the file to upload",
                                        verify_block: proc do |value|

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_file.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_file.rb
@@ -7,16 +7,16 @@ module Fastlane
         Helper::SentryHelper.check_sentry_cli!
         Helper::SentryConfig.parse_api_params(params)
 
-        version = params[:version]
         file = params[:file]
 
+        version = params[:version]
         version = "#{params[:app_identifier]}-#{params[:version]}" if params[:app_identifier]
 
         command = [
           "sentry-cli",
           "releases",
           "files",
-          Shellwords.escape(version),
+          version,
           "upload",
           file
         ]
@@ -56,7 +56,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :file_url,
                                        description: "Optional URL we should associate with the file",
                                        optional: true),
-
           FastlaneCore::ConfigItem.new(key: :app_identifier,
                                       short_option: "-a",
                                       env_name: "SENTRY_APP_IDENTIFIER",

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
@@ -51,7 +51,8 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version,
                                        description: "Release version on Sentry"),
           FastlaneCore::ConfigItem.new(key: :dist,
-                                       description: "Distribution in release"),
+                                       description: "Distribution in release",
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :sourcemap,
                                        description: "Path to the sourcemap to upload",
                                        verify_block: proc do |value|

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
@@ -24,8 +24,8 @@ module Fastlane
         command.push('--rewrite') if params[:rewrite]
         command.push('--strip-prefix') if params[:strip_prefix]
         command.push('--strip-common-prefix') if params[:strip_common_prefix]
-        command.push('--url-prefix').push(params[:url_prefix]) if !params[:url_prefix].nil?
-        command.push('--dist').push(params[:dist]) if !params[:dist].nil?
+        command.push('--url-prefix').push(params[:url_prefix]) unless params[:url_prefix].nil?
+        command.push('--dist').push(params[:dist]) unless params[:dist].nil?
 
         Helper::SentryHelper.call_sentry_cli(command)
         UI.success("Successfully uploaded files to release: #{version}")

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
@@ -12,25 +12,20 @@ module Fastlane
 
         version = "#{params[:app_identifier]}-#{params[:version]}" if params[:app_identifier]
 
-        rewrite_arg = params[:rewrite] ? '--rewrite' : ''
-        strip_prefix_arg = params[:strip_prefix] ? '--strip-prefix' : ''
-        strip_common_prefix_arg = params[:strip_common_prefix] ? '--strip-common-prefix' : ''
-        url_prefix_arg = params[:url_prefix] ? "--url-prefix '#{params[:url_prefix]}'" : ''
-        dist_arg = params[:dist] ? "--dist '#{params[:dist]}'" : ''
-
         command = [
           "sentry-cli",
           "releases",
           "files",
-          "'#{Shellwords.escape(version)}'",
+          Shellwords.escape(version),
           "upload-sourcemaps",
-          sourcemap.to_s,
-          rewrite_arg,
-          strip_prefix_arg,
-          strip_common_prefix_arg,
-          url_prefix_arg,
-          dist_arg
-        ].join(" ")
+          sourcemap.to_s
+        ]
+
+        command.push('--rewrite') if params[:rewrite]
+        command.push('--strip-prefix') if params[:strip_prefix]
+        command.push('--strip-common-prefix') if params[:strip_common_prefix]
+        command.push('--url-prefix').push(params[:url_prefix]) if !params[:url_prefix].nil?
+        command.push('--dist').push(params[:dist]) if !params[:dist].nil?
 
         Helper::SentryHelper.call_sentry_cli(command)
         UI.success("Successfully uploaded files to release: #{version}")

--- a/lib/fastlane/plugin/sentry/helper/sentry_helper.rb
+++ b/lib/fastlane/plugin/sentry/helper/sentry_helper.rb
@@ -31,7 +31,8 @@ module Fastlane
           UI.command(command.to_s)
           UI.verbose("\n\n")
         end
-        Open3.popen3(command.join(" ")) do |stdin, stdout, stderr, wait_thr|
+        final_command = command.map { |arg| Shellwords.escape(arg) }.join(" ")
+        Open3.popen3(final_command) do |stdin, stdout, stderr, wait_thr|
           while (line = stderr.gets)
             error << line.strip!
           end

--- a/lib/fastlane/plugin/sentry/helper/sentry_helper.rb
+++ b/lib/fastlane/plugin/sentry/helper/sentry_helper.rb
@@ -31,7 +31,7 @@ module Fastlane
           UI.command(command.to_s)
           UI.verbose("\n\n")
         end
-        Open3.popen3(command) do |stdin, stdout, stderr, wait_thr|
+        Open3.popen3(command.join(" ")) do |stdin, stdout, stderr, wait_thr|
           while (line = stderr.gets)
             error << line.strip!
           end

--- a/lib/fastlane/plugin/sentry/version.rb
+++ b/lib/fastlane/plugin/sentry/version.rb
@@ -1,6 +1,6 @@
 module Fastlane
   module Sentry
-    VERSION = "1.2.4"
+    VERSION = "1.2.5"
     CLI_VERSION = "1.9.0"
   end
 end

--- a/lib/fastlane/plugin/sentry/version.rb
+++ b/lib/fastlane/plugin/sentry/version.rb
@@ -1,6 +1,6 @@
 module Fastlane
   module Sentry
-    VERSION = "1.2.3"
+    VERSION = "1.2.4"
     CLI_VERSION = "1.9.0"
   end
 end

--- a/lib/fastlane/plugin/sentry/version.rb
+++ b/lib/fastlane/plugin/sentry/version.rb
@@ -1,6 +1,6 @@
 module Fastlane
   module Sentry
-    VERSION = "1.2.5"
+    VERSION = "1.2.6"
     CLI_VERSION = "1.9.0"
   end
 end

--- a/spec/sentry_create_release_spec.rb
+++ b/spec/sentry_create_release_spec.rb
@@ -5,7 +5,7 @@ describe Fastlane do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with("sentry-cli releases new 'app.idf-1.0' ").and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "new", "app.idf-1.0"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_create_release(

--- a/spec/sentry_upload_file_spec.rb
+++ b/spec/sentry_upload_file_spec.rb
@@ -13,6 +13,26 @@ describe Fastlane do
           end").runner.execute(:test)
         end.to raise_error("Could not find file at path '#{file_path}'")
       end
+
+      it "does not require dist to be specified" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "app.idf-1.0", "upload", "demo.file"]).and_return(true)
+
+        allow(File).to receive(:exist?).and_call_original
+        expect(File).to receive(:exist?).with("demo.file").and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_file(
+              org_slug: 'some_org',
+              api_key: 'something123',
+              project_slug: 'some_project',
+              version: '1.0',
+              file: 'demo.file',
+              app_identifier: 'app.idf')
+        end").runner.execute(:test)
+      end
+
       it "accepts app_identifier" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)

--- a/spec/sentry_upload_file_spec.rb
+++ b/spec/sentry_upload_file_spec.rb
@@ -17,8 +17,9 @@ describe Fastlane do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with("sentry-cli releases files 'app.idf-1.0' upload demo.file  --dist 'dem'").and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "app.idf-1.0", "upload", "demo.file", "--dist", "dem"]).and_return(true)
 
+        allow(File).to receive(:exist?).and_call_original
         expect(File).to receive(:exist?).with("demo.file").and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do

--- a/spec/sentry_upload_sourcemap_spec.rb
+++ b/spec/sentry_upload_sourcemap_spec.rb
@@ -13,6 +13,26 @@ describe Fastlane do
           end").runner.execute(:test)
         end.to raise_error("Could not find sourcemap at path '#{sourcemap_path}'")
       end
+
+      it "does not require dist to be specified" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "app.idf-1.0", "upload-sourcemaps", "1.map"]).and_return(true)
+
+        allow(File).to receive(:exist?).and_call_original
+        expect(File).to receive(:exist?).with("1.map").and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_sourcemap(
+              org_slug: 'some_org',
+              api_key: 'something123',
+              project_slug: 'some_project',
+              version: '1.0',
+              sourcemap: '1.map',
+              app_identifier: 'app.idf')
+        end").runner.execute(:test)
+      end
+
       it "accepts app_identifier" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)

--- a/spec/sentry_upload_sourcemap_spec.rb
+++ b/spec/sentry_upload_sourcemap_spec.rb
@@ -17,7 +17,9 @@ describe Fastlane do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with("sentry-cli releases files 'app.idf-1.0' upload-sourcemaps 1.map     --dist 'dem'").and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "app.idf-1.0", "upload-sourcemaps", "1.map", "--dist", "dem"]).and_return(true)
+
+        allow(File).to receive(:exist?).and_call_original
         expect(File).to receive(:exist?).with("1.map").and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do


### PR DESCRIPTION
To match behavior prior to adding of `dist` argument (411c12a19879d06c822a0047f9db78ad7bbc39e0), `false` must be specified for the argument or else the CLI asks for the value and hangs when an empty string is entered.