### PR TITLE
Remove default value from app_identifier argument

### DIFF
--- a/lib/fastlane/plugin/sentry/actions/sentry_create_release.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_create_release.rb
@@ -49,9 +49,8 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :app_identifier,
                                       short_option: "-a",
                                       env_name: "SENTRY_APP_IDENTIFIER",
-                                      description: "App Bundle Identifier",
-                                      optional: true,
-                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier))
+                                      description: "App Bundle Identifier, prepended to version",
+                                      optional: true)
 
         ]
       end

--- a/lib/fastlane/plugin/sentry/actions/sentry_finalize_release.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_finalize_release.rb
@@ -43,9 +43,8 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :app_identifier,
                                       short_option: "-a",
                                       env_name: "SENTRY_APP_IDENTIFIER",
-                                      description: "App Bundle Identifier",
-                                      optional: true,
-                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier))
+                                      description: "App Bundle Identifier, prepended to version",
+                                      optional: true)
 
         ]
       end

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_file.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_file.rb
@@ -59,9 +59,8 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :app_identifier,
                                       short_option: "-a",
                                       env_name: "SENTRY_APP_IDENTIFIER",
-                                      description: "App Bundle Identifier",
-                                      optional: true,
-                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier))
+                                      description: "App Bundle Identifier, prepended to version",
+                                      optional: true)
         ]
       end
 

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
@@ -80,9 +80,8 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :app_identifier,
                                       short_option: "-a",
                                       env_name: "SENTRY_APP_IDENTIFIER",
-                                      description: "App Bundle Identifier",
-                                      optional: true,
-                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier))
+                                      description: "App Bundle Identifier, prepended to version",
+                                      optional: true)
 
         ]
       end

--- a/spec/sentry_create_release_spec.rb
+++ b/spec/sentry_create_release_spec.rb
@@ -13,6 +13,17 @@ describe Fastlane do
               app_identifier: 'app.idf')
         end").runner.execute(:test)
       end
+
+      it "does not prepend app_identifier if not specified" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "new", "1.0"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_create_release(
+              version: '1.0')
+        end").runner.execute(:test)
+      end
     end
   end
 end

--- a/spec/sentry_upload_file_spec.rb
+++ b/spec/sentry_upload_file_spec.rb
@@ -13,6 +13,7 @@ describe Fastlane do
           end").runner.execute(:test)
         end.to raise_error("Could not find file at path '#{file_path}'")
       end
+
       it "accepts app_identifier" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
@@ -31,6 +32,25 @@ describe Fastlane do
               dist: 'dem',
               file: 'demo.file',
               app_identifier: 'app.idf')
+        end").runner.execute(:test)
+      end
+
+      it "does not prepend app_identifier if not specified" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "1.0", "upload", "demo.file", "--dist", "dem"]).and_return(true)
+
+        allow(File).to receive(:exist?).and_call_original
+        expect(File).to receive(:exist?).with("demo.file").and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_file(
+              org_slug: 'some_org',
+              api_key: 'something123',
+              project_slug: 'some_project',
+              version: '1.0',
+              dist: 'dem',
+              file: 'demo.file')
         end").runner.execute(:test)
       end
     end

--- a/spec/sentry_upload_sourcemap_spec.rb
+++ b/spec/sentry_upload_sourcemap_spec.rb
@@ -13,6 +13,7 @@ describe Fastlane do
           end").runner.execute(:test)
         end.to raise_error("Could not find sourcemap at path '#{sourcemap_path}'")
       end
+
       it "accepts app_identifier" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
@@ -31,6 +32,25 @@ describe Fastlane do
               dist: 'dem',
               sourcemap: '1.map',
               app_identifier: 'app.idf')
+        end").runner.execute(:test)
+      end
+
+      it "does not prepend app_identifier if not specified" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "1.0", "upload-sourcemaps", "1.map", "--dist", "dem"]).and_return(true)
+
+        allow(File).to receive(:exist?).and_call_original
+        expect(File).to receive(:exist?).with("1.map").and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_sourcemap(
+              org_slug: 'some_org',
+              api_key: 'something123',
+              project_slug: 'some_project',
+              version: '1.0',
+              dist: 'dem',
+              sourcemap: '1.map')
         end").runner.execute(:test)
       end
     end


### PR DESCRIPTION
Resolves #22 

Summary:

Removes the default value for app_identifier so that users releases aren't affected.

Test Plan:
- Run the added tests.
- Test locally with app, ensure that previous version numbering scheme is maintained by default.