### PR TITLE
Make dist parameter optional to match CLI behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ sentry_upload_file(
   project_slug: '...',
   version: '...',
   app_identifier: '...', # pass in the bundle_identifer of your app
-  dist: '...', # distribution of the release usually the buildnumber
+  dist: '...', # optional distribution of the release usually the buildnumber
   file: 'main.jsbundle' # file to upload
 )
 ```
@@ -76,7 +76,7 @@ sentry_upload_sourcemap(
   project_slug: '...',
   version: '...',
   app_identifier: '...', # pass in the bundle_identifer of your app
-  dist: '...', # distribution of the release usually the buildnumber
+  dist: '...', # optional distribution of the release usually the buildnumber
   sourcemap: 'main.jsbundle.map', # sourcemap to upload
   rewrite: true
 )

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_file.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_file.rb
@@ -47,7 +47,8 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version,
                                        description: "Release version on Sentry"),
           FastlaneCore::ConfigItem.new(key: :dist,
-                                       description: "Distribution in release"),
+                                       description: "Distribution in release",
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :file,
                                        description: "Path to the file to upload",
                                        verify_block: proc do |value|

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
@@ -51,7 +51,8 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version,
                                        description: "Release version on Sentry"),
           FastlaneCore::ConfigItem.new(key: :dist,
-                                       description: "Distribution in release"),
+                                       description: "Distribution in release",
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :sourcemap,
                                        description: "Path to the sourcemap to upload",
                                        verify_block: proc do |value|

--- a/spec/sentry_upload_file_spec.rb
+++ b/spec/sentry_upload_file_spec.rb
@@ -14,6 +14,25 @@ describe Fastlane do
         end.to raise_error("Could not find file at path '#{file_path}'")
       end
 
+      it "does not require dist to be specified" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "app.idf-1.0", "upload", "demo.file"]).and_return(true)
+
+        allow(File).to receive(:exist?).and_call_original
+        expect(File).to receive(:exist?).with("demo.file").and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_file(
+              org_slug: 'some_org',
+              api_key: 'something123',
+              project_slug: 'some_project',
+              version: '1.0',
+              file: 'demo.file',
+              app_identifier: 'app.idf')
+        end").runner.execute(:test)
+      end
+
       it "accepts app_identifier" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)

--- a/spec/sentry_upload_sourcemap_spec.rb
+++ b/spec/sentry_upload_sourcemap_spec.rb
@@ -14,6 +14,25 @@ describe Fastlane do
         end.to raise_error("Could not find sourcemap at path '#{sourcemap_path}'")
       end
 
+      it "does not require dist to be specified" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "app.idf-1.0", "upload-sourcemaps", "1.map"]).and_return(true)
+
+        allow(File).to receive(:exist?).and_call_original
+        expect(File).to receive(:exist?).with("1.map").and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_sourcemap(
+              org_slug: 'some_org',
+              api_key: 'something123',
+              project_slug: 'some_project',
+              version: '1.0',
+              sourcemap: '1.map',
+              app_identifier: 'app.idf')
+        end").runner.execute(:test)
+      end
+
       it "accepts app_identifier" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)


### PR DESCRIPTION
Copied from outdated PR:

Summary:
The dist argument addition made it so that users needed to add dist: false to their call to sentry_upload_file to match previous behavior, which isn't obvious at first glance. Without providing a value, the argument defaults to '' (empty string), which causes the CLI to prompt for the arg. The CLI has a separate bug in which it hangs if no text is entered in the prompt.

I think the best solution is this PR, which makes the fastlane plugin signature match the CLI signature of the dist arg being optional, which prevents users from having to provide false as a value to the string argument to prevent being prompted for a value.

CLI spec: https://github.com/getsentry/sentry-cli/blob/0dd8e59f1f38581a2d66de6f4666f29acfc236a7/src/commands/releases.rs#L165

Test Plan:
- run new tests
- use in app fastlane to test uploading files, ensure not specifying `dist` doesn't prompt for it.